### PR TITLE
Drop loop kwarg from async_timeout.timeout

### DIFF
--- a/pylaunches/common.py
+++ b/pylaunches/common.py
@@ -17,7 +17,7 @@ async def call_api(
     if token is not None:
         headers["Token"] = token
     try:
-        async with async_timeout.timeout(20, loop=get_event_loop()):
+        async with async_timeout.timeout(20):
             response = await session.get(endpoint, headers=headers)
             if response.status != 200:
                 raise PyLaunchesException(f"Unexpected statuscode {response.status}")


### PR DESCRIPTION
- async_timeout 4.0.0 drops the loop= kwarg and will fail if its passed