### PR TITLE
Add starship endpoint

### DIFF
--- a/pylaunches/api.py
+++ b/pylaunches/api.py
@@ -60,6 +60,6 @@ class PyLaunches:
         response = StarshipResponse(
             await call_api(self.session, f"{BASE_URL}/dashboard/starship/", self.token)
         )
-        if not response.previous:
+        if not response.previous.launches:
             raise PyLaunchesNoData("No starship data.")
         return response

--- a/pylaunches/api.py
+++ b/pylaunches/api.py
@@ -13,6 +13,7 @@ from pylaunches.common import call_api
 from pylaunches.const import BASE_URL
 from pylaunches.exceptions import PyLaunchesNoData
 from pylaunches.objects.launch import Launch, LaunchResponse
+from pylaunches.objects.starship import StarshipResponse
 
 
 class PyLaunches:
@@ -51,5 +52,14 @@ class PyLaunches:
             await call_api(self.session, f"{BASE_URL}/launch/upcoming/", self.token)
         )
         if not response.results:
-            raise PyLaunchesNoData("No data")
+            raise PyLaunchesNoData("No launch data")
         return response.results
+
+    async def starship_events(self) -> StarshipResponse or None:
+        """Get upcoming launch information for starship."""
+        response = StarshipResponse(
+            await call_api(self.session, f"{BASE_URL}/dashboard/starship/", self.token)
+        )
+        if not response:
+            raise PyLaunchesNoData("No starship data.")
+        return response

--- a/pylaunches/api.py
+++ b/pylaunches/api.py
@@ -60,6 +60,6 @@ class PyLaunches:
         response = StarshipResponse(
             await call_api(self.session, f"{BASE_URL}/dashboard/starship/", self.token)
         )
-        if not response:
+        if not response.previous:
             raise PyLaunchesNoData("No starship data.")
         return response

--- a/pylaunches/objects/event.py
+++ b/pylaunches/objects/event.py
@@ -1,0 +1,66 @@
+from pylaunches.objects.data import PyLaunchesData
+from pylaunches.objects.launch import Launch
+
+
+class EventType(PyLaunchesData):
+    """Event type data object."""
+
+    @property
+    def id(self) -> str:
+        return self._data.get("id")
+
+    @property
+    def name(self) -> str:
+        return self._data.get("name")
+
+
+class Event(PyLaunchesData):
+    """Event data object."""
+
+    @property
+    def id(self) -> str:
+        return self._data.get("id")
+
+    @property
+    def url(self) -> str:
+        return self._data.get("url")
+
+    @property
+    def slug(self) -> str:
+        return self._data.get("slug")
+
+    @property
+    def name(self) -> str:
+        return self._data.get("name")
+
+    @property
+    def type(self) -> EventType:
+        return EventType(self._data.get("type", {}))
+
+    @property
+    def description(self) -> str:
+        return self._data.get("description")
+
+    @property
+    def location(self) -> str:
+        return self._data.get("location")
+
+    @property
+    def news_url(self) -> str:
+        return self._data.get("news_url")
+
+    @property
+    def video_url(self) -> str:
+        return self._data.get("video_url")
+
+    @property
+    def feature_image(self) -> str:
+        return self._data.get("feature_image")
+
+    @property
+    def date(self) -> str:
+        return self._data.get("date")
+
+    @property
+    def launches(self) -> Launch:
+        return [Launch(x) for x in self._data.get("launches", [])]

--- a/pylaunches/objects/starship.py
+++ b/pylaunches/objects/starship.py
@@ -1,0 +1,143 @@
+from typing import Dict, List
+
+from pylaunches.objects.data import PyLaunchesData
+from pylaunches.objects.event import Event
+from pylaunches.objects.launch import Launch, RocketConfiguration
+
+
+class LiveStream(PyLaunchesData):
+    """Live Stream data object."""
+
+    @property
+    def title(self) -> str:
+        return self._data.get("title")
+
+    @property
+    def description(self) -> str:
+        return self._data.get("description")
+
+    @property
+    def image(self) -> str:
+        return self._data.get("image")
+
+    @property
+    def url(self) -> str:
+        return self._data.get("url")
+
+
+class RoadClosureStatus(PyLaunchesData):
+    """Road closure status data object."""
+
+    @property
+    def id(self) -> str:
+        return self._data.get("id")
+
+    @property
+    def name(self) -> str:
+        return self._data.get("name")
+
+
+class RoadClosure(PyLaunchesData):
+    """Road closure data object."""
+
+    @property
+    def id(self) -> str:
+        return self._data.get("id")
+
+    @property
+    def title(self) -> str:
+        return self._data.get("title")
+
+    @property
+    def status(self) -> RoadClosureStatus:
+        return RoadClosureStatus(self._data.get("status", {}))
+
+    @property
+    def window_start(self) -> str:
+        return self._data.get("window_start")
+
+    @property
+    def window_end(self) -> str:
+        return self._data.get("window_end")
+
+
+class Vehicle(PyLaunchesData):
+    """Vehicle data object."""
+
+    @property
+    def id(self) -> str:
+        return self._data.get("id")
+
+    @property
+    def url(self) -> str:
+        return self._data.get("url")
+
+    @property
+    def flight_proven(self) -> bool:
+        return self._data.get("flight_proven")
+
+    @property
+    def serial_number(self) -> str:
+        return self._data.get("serial_number")
+
+    @property
+    def status(self) -> str:
+        return self._data.get("status")
+
+    @property
+    def details(self) -> str:
+        return self._data.get("details")
+
+    @property
+    def launcher_config(self) -> RocketConfiguration:
+        return RocketConfiguration(self._data.get("launcher_config", {}))
+
+    @property
+    def image_url(self) -> str:
+        return self._data.get("image_url")
+
+    @property
+    def flights(self) -> int:
+        return self._data.get("flights")
+
+    @property
+    def last_launch_date(self) -> str:
+        return self._data.get("last_launch_date")
+
+    @property
+    def first_launch_date(self) -> str:
+        return self._data.get("first_launch_date")
+
+
+class StarshipEvents(PyLaunchesData):
+    """Starship launches and events data object."""
+
+    @property
+    def launches(self) -> List[Launch]:
+        return [Launch(x) for x in self._data.get("launches", [])]
+
+    @property
+    def events(self) -> List[Event]:
+        return [Event(x) for x in self._data.get("events", [])]
+
+
+class StarshipResponse(PyLaunchesData):
+    @property
+    def upcoming(self) -> StarshipEvents:
+        return StarshipEvents(self._data.get("upcoming", {}))
+
+    @property
+    def previous(self) -> StarshipEvents:
+        return StarshipEvents(self._data.get("previous", {}))
+
+    @property
+    def live_streams(self) -> List[LiveStream]:
+        return [LiveStream(x) for x in self._data.get("live_streams", [])]
+
+    @property
+    def road_closures(self) -> List[RoadClosure]:
+        return [RoadClosure(x) for x in self._data.get("road_closures", [])]
+
+    @property
+    def vehicles(self) -> List[Vehicle]:
+        return [Vehicle(x) for x in self._data.get("vehicles", [])]

--- a/tests/fixtures/starship.json
+++ b/tests/fixtures/starship.json
@@ -77,7 +77,52 @@
           }
        ],
        "events":[
-          
+            {
+                "id":1,
+                "url":"https://example.com/",
+                "slug":"example-01",
+                "name":"Example | Example-01",
+                "type":{
+                "id":1,
+                "name":"Launch"
+                },
+                "description":"This is a description of something, hope you like it.",
+                "location":"Top Secret, EARTH",
+                "news_url":"https://example.com/",
+                "video_url":"https://example.com/",
+                "feature_image":"https://example.com/image.jpg",
+                "date":"1970-01-01T00:00:00Z",
+                "launches":[
+                
+                ],
+                "expeditions":[
+                
+                ],
+                "spacestations":[
+                
+                ],
+                "program":[
+                {
+                    "id":1,
+                    "url":"https://example.com",
+                    "name":"SpaceX Starship",
+                    "description":"This is a description of something, hope you like it.",
+                    "agencies":[
+                        {
+                            "id":1,
+                            "url":"https://example.com",
+                            "name":"SpaceX",
+                            "type":"Commercial"
+                        }
+                    ],
+                    "image_url":"https://example.com/image.jpg",
+                    "start_date":"1970-01-01T00:00:00Z",
+                    "end_date":"1970-01-01T00:00:00Z",
+                    "info_url":"https://example.com",
+                    "wiki_url":"https://example.com"
+                }
+                ]
+            }
        ]
     },
     "previous":{

--- a/tests/fixtures/starship.json
+++ b/tests/fixtures/starship.json
@@ -1,0 +1,255 @@
+{
+    "upcoming":{
+       "launches":[
+        {
+            "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+            "url": "https://example.com",
+            "launch_library_id": 1,
+            "slug": "example-01",
+            "name": "Example | Example-01",
+            "status": {
+              "id": 1,
+              "name": "Go"
+            },
+            "net": "1970-01-01T00:00:00z",
+            "window_end": "1970-01-01T00:00:00Z",
+            "window_start": "1970-01-01T00:00:00Z",
+            "inhold": false,
+            "tbdtime": false,
+            "tbddate": false,
+            "probability": 90,
+            "holdreason": "",
+            "failreason": "",
+            "hashtag": null,
+            "launch_service_provider": {
+              "id": 124,
+              "url": "https://example.com",
+              "name": "Example Launch Provider",
+              "type": "Commercial"
+            },
+            "rocket": {
+              "id": 1,
+              "configuration": {
+                "id": 1,
+                "launch_library_id": 1,
+                "url": "https://example.com",
+                "name": "Example-01",
+                "family": "Example",
+                "full_name": "Example-01",
+                "variant": "Example"
+              }
+            },
+            "mission": {
+              "id": 1,
+              "launch_library_id": 1,
+              "name": "NROL-101",
+              "description": "Lorem ipsum.",
+              "launch_designator": null,
+              "type": "Top Secret",
+              "orbit": null
+            },
+            "pad": {
+              "id": 1,
+              "url": "https://example.com",
+              "agency_id": null,
+              "name": "Example Launch Pad",
+              "info_url": null,
+              "wiki_url": "https://example.com",
+              "map_url": "https://example.com",
+              "latitude": "00.000000000",
+              "longitude": "-00.00000000",
+              "location": {
+                "id": 1,
+                "url": "https://example.com",
+                "name": "Top Secret, EARTH",
+                "country_code": "EARTH",
+                "map_image": "https://example.com/image.jpg",
+                "total_launch_count": 1,
+                "total_landing_count": 0
+              },
+              "map_image": "https://example.com/image.jpg",
+              "total_launch_count": 1
+            },
+            "webcast_live": false,
+            "image": "https://example.com/image.jpg",
+            "infographic": "https://example.com/image.jpg",
+            "program": []
+          }
+       ],
+       "events":[
+          
+       ]
+    },
+    "previous":{
+       "launches":[
+        {
+            "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+            "url": "https://example.com",
+            "launch_library_id": 1,
+            "slug": "example-01",
+            "name": "Example | Example-01",
+            "status": {
+              "id": 1,
+              "name": "Go"
+            },
+            "net": "1970-01-01T00:00:00z",
+            "window_end": "1970-01-01T00:00:00Z",
+            "window_start": "1970-01-01T00:00:00Z",
+            "inhold": false,
+            "tbdtime": false,
+            "tbddate": false,
+            "probability": 90,
+            "holdreason": "",
+            "failreason": "",
+            "hashtag": null,
+            "launch_service_provider": {
+              "id": 124,
+              "url": "https://example.com",
+              "name": "Example Launch Provider",
+              "type": "Commercial"
+            },
+            "rocket": {
+              "id": 1,
+              "configuration": {
+                "id": 1,
+                "launch_library_id": 1,
+                "url": "https://example.com",
+                "name": "Example-01",
+                "family": "Example",
+                "full_name": "Example-01",
+                "variant": "Example"
+              }
+            },
+            "mission": {
+              "id": 1,
+              "launch_library_id": 1,
+              "name": "NROL-101",
+              "description": "Lorem ipsum.",
+              "launch_designator": null,
+              "type": "Top Secret",
+              "orbit": null
+            },
+            "pad": {
+              "id": 1,
+              "url": "https://example.com",
+              "agency_id": null,
+              "name": "Example Launch Pad",
+              "info_url": null,
+              "wiki_url": "https://example.com",
+              "map_url": "https://example.com",
+              "latitude": "00.000000000",
+              "longitude": "-00.00000000",
+              "location": {
+                "id": 1,
+                "url": "https://example.com",
+                "name": "Top Secret, EARTH",
+                "country_code": "EARTH",
+                "map_image": "https://example.com/image.jpg",
+                "total_launch_count": 1,
+                "total_landing_count": 0
+              },
+              "map_image": "https://example.com/image.jpg",
+              "total_launch_count": 1
+            },
+            "webcast_live": false,
+            "image": "https://example.com/image.jpg",
+            "infographic": "https://example.com/image.jpg",
+            "program": []
+          }
+       ],
+       "events":[
+          {
+             "id":1,
+             "url":"https://example.com/",
+             "slug":"example-01",
+             "name":"Example | Example-01",
+             "type":{
+                "id":1,
+                "name":"Launch"
+             },
+             "description":"This is a description of something, hope you like it.",
+             "location":"Top Secret, EARTH",
+             "news_url":"https://example.com/",
+             "video_url":"https://example.com/",
+             "feature_image":"https://example.com/image.jpg",
+             "date":"1970-01-01T00:00:00Z",
+             "launches":[
+                
+             ],
+             "expeditions":[
+                
+             ],
+             "spacestations":[
+                
+             ],
+             "program":[
+                {
+                   "id":1,
+                   "url":"https://example.com",
+                   "name":"SpaceX Starship",
+                   "description":"This is a description of something, hope you like it.",
+                   "agencies":[
+                      {
+                         "id":1,
+                         "url":"https://example.com",
+                         "name":"SpaceX",
+                         "type":"Commercial"
+                      }
+                   ],
+                   "image_url":"https://example.com/image.jpg",
+                   "start_date":"1970-01-01T00:00:00Z",
+                   "end_date":"1970-01-01T00:00:00Z",
+                   "info_url":"https://example.com",
+                   "wiki_url":"https://example.com"
+                }
+             ]
+          }
+       ]
+    },
+    "live_streams":[
+       {
+          "title":"24/7 Livestream",
+          "description":"This is a description of something, hope you like it.",
+          "image":"https://example.com/image.jpg",
+          "url":"https://example.com"
+       }
+    ],
+    "road_closures":[
+       {
+          "id":1,
+          "title":"Primary Date",
+          "status":{
+             "id":1,
+             "name":"Scheduled"
+          },
+          "window_start":"1970-01-01T00:00:00Z",
+          "window_end":"1970-01-01T00:00:00Z"
+       }
+    ],
+    "notices":[
+       
+    ],
+    "vehicles":[
+       {
+          "id":1,
+          "url":"https://example.com",
+          "flight_proven":false,
+          "serial_number":"BN1",
+          "status":"scrapped",
+          "details":"This is a description of something, hope you like it.",
+          "launcher_config":{
+            "id": 1,
+            "launch_library_id": 1,
+            "url": "https://example.com",
+            "name": "Example-01",
+            "family": "Example",
+            "full_name": "Example-01",
+            "variant": "Example"
+          },
+          "image_url":"https://example.com/image.jpg",
+          "flights":0,
+          "last_launch_date":"1970-01-01T00:00:00Z",
+          "first_launch_date":"1970-01-01T00:00:00Z"
+       }
+    ]
+ }

--- a/tests/test_get_starship.py
+++ b/tests/test_get_starship.py
@@ -40,13 +40,13 @@ async def test_starship_events_exceptions(aresponses):
         "ll.thespacedevs.com",
         "/2.0.0/dashboard/starship/",
         "get",
-        aresponses.Response(text="{}", headers=HEADERS),
+        aresponses.Response(text=None, headers=HEADERS),
     )
     aresponses.add(
         "ll.thespacedevs.com",
         "/2.0.0/dashboard/starship/",
         "get",
-        aresponses.Response(text="{}", headers=HEADERS, status=500),
+        aresponses.Response(text=None, headers=HEADERS, status=500),
     )
 
     async with PyLaunches() as client:

--- a/tests/test_get_starship.py
+++ b/tests/test_get_starship.py
@@ -40,13 +40,13 @@ async def test_starship_events_exceptions(aresponses):
         "ll.thespacedevs.com",
         "/2.0.0/dashboard/starship/",
         "get",
-        aresponses.Response(text=None, headers=HEADERS),
+        aresponses.Response(text="{}", headers=HEADERS),
     )
     aresponses.add(
         "ll.thespacedevs.com",
         "/2.0.0/dashboard/starship/",
         "get",
-        aresponses.Response(text=None, headers=HEADERS, status=500),
+        aresponses.Response(text="{}", headers=HEADERS, status=500),
     )
 
     async with PyLaunches() as client:

--- a/tests/test_get_starship.py
+++ b/tests/test_get_starship.py
@@ -1,0 +1,58 @@
+import aiohttp
+import pytest
+
+from pylaunches import PyLaunches, PyLaunchesException, PyLaunchesNoData
+from pylaunches.const import HEADERS
+from tests.common import fixture
+
+
+@pytest.mark.asyncio
+async def test_starship_events(aresponses):
+    response = fixture("starship.json", False)
+    aresponses.add(
+        "ll.thespacedevs.com",
+        "/2.0.0/dashboard/starship/",
+        "get",
+        aresponses.Response(text=response, headers=HEADERS),
+    )
+
+    async with PyLaunches() as client:
+        starship = await client.starship_events()
+        upcoming_launch = starship.upcoming.launches[0]
+        assert upcoming_launch.name == "Example | Example-01"
+        upcoming_event = starship.upcoming.events[0]
+        assert upcoming_event.name == "Example | Example-01"
+        previous_launch = starship.previous.launches[0]
+        assert previous_launch.name == "Example | Example-01"
+        previous_event = starship.upcoming.events[0]
+        assert previous_event.name == "Example | Example-01"
+        live_stream = starship.live_streams[0]
+        assert live_stream.title == "24/7 Livestream"
+        road_closure = starship.road_closures[0]
+        assert road_closure.title == "Primary Date"
+        vehicle = starship.vehicles[0]
+        assert vehicle.serial_number == "BN1"
+
+
+@pytest.mark.asyncio
+async def test_starship_events_exceptions(aresponses):
+    aresponses.add(
+        "ll.thespacedevs.com",
+        "/2.0.0/dashboard/starship/",
+        "get",
+        aresponses.Response(text="{}", headers=HEADERS),
+    )
+    aresponses.add(
+        "ll.thespacedevs.com",
+        "/2.0.0/dashboard/starship/",
+        "get",
+        aresponses.Response(text="{}", headers=HEADERS, status=500),
+    )
+
+    async with PyLaunches() as client:
+        with pytest.raises(PyLaunchesNoData):
+            await client.starship_events()
+
+    async with PyLaunches() as client:
+        with pytest.raises(PyLaunchesException):
+            await client.starship_events()


### PR DESCRIPTION
This adds the endpoint for starship events and launches.  https://ll.thespacedevs.com/2.0.0/swagger

I  have purposely left out some attributes to limit this rather big PR. I will add them down the line.

Example of the attribute left out:
In the event object, there should also be an object containing which programs it is associated with, but this is also part of a separate endpoint so i believe it is better to add this part when adding the other endpoint. If this does not make sense I will added (Though it will make this PR even bigger).