### PR TITLE
Remove the ability to use a custom API version

### DIFF
--- a/pylaunches/api.py
+++ b/pylaunches/api.py
@@ -18,6 +18,7 @@ from .types import Event, Launch, StarshipResponse, PyLaunchesResponse
 
 LOGGER: Logger = getLogger(__package__)
 
+
 class PyLaunches:
     """A class to get launch information."""
 
@@ -36,7 +37,7 @@ class PyLaunches:
         if self.session is None:
             self.session = ClientSession()
             self._close_session = True
-            
+
         self._base_url = f"{DEV_BASE_URL if dev else BASE_URL}/{API_VERSION}"
 
     async def __aenter__(self) -> PyLaunches:

--- a/pylaunches/api.py
+++ b/pylaunches/api.py
@@ -7,14 +7,16 @@ file for more details.
 
 from __future__ import annotations
 from asyncio import CancelledError
+from logging import getLogger, Logger
 from typing import Mapping
 
 from aiohttp import ClientSession, ClientTimeout
 
-from .const import BASE_URL, DEFAULT_API_VERSION, DEV_BASE_URL, HEADERS
+from .const import API_VERSION, BASE_URL, DEV_BASE_URL, HEADERS
 from .exceptions import PyLaunchesError
 from .types import Event, Launch, StarshipResponse, PyLaunchesResponse
 
+LOGGER: Logger = getLogger(__package__)
 
 class PyLaunches:
     """A class to get launch information."""
@@ -26,7 +28,6 @@ class PyLaunches:
         session: ClientSession | None = None,
         token: str = None,
         *,
-        api_version: str = DEFAULT_API_VERSION,
         dev: bool = False,
     ) -> None:
         """Initialize the class."""
@@ -35,8 +36,8 @@ class PyLaunches:
         if self.session is None:
             self.session = ClientSession()
             self._close_session = True
-
-        self._base_url = f"{DEV_BASE_URL if dev else BASE_URL}/{api_version}"
+            
+        self._base_url = f"{DEV_BASE_URL if dev else BASE_URL}/{API_VERSION}"
 
     async def __aenter__(self) -> PyLaunches:
         """Async enter."""

--- a/pylaunches/const.py
+++ b/pylaunches/const.py
@@ -2,7 +2,7 @@
 
 BASE_URL = "https://ll.thespacedevs.com"
 DEV_BASE_URL = "https://lldev.thespacedevs.com"
-DEFAULT_API_VERSION = "2.2.0"
+API_VERSION = "2.2.0"
 
 DOCUMENTATION = "https://thespacedevs.com/llapi"
 HEADERS = {

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,24 +1,17 @@
 import pytest
 from pylaunches import PyLaunches
-from pylaunches.const import BASE_URL, DEFAULT_API_VERSION, DEV_BASE_URL
+from pylaunches.const import API_VERSION, BASE_URL, DEV_BASE_URL
 
 
 @pytest.mark.asyncio
 async def test_default_api_version():
-    """Test default api version."""
+    """Test default URL."""
     async with PyLaunches() as client:
-        assert client._base_url == f"{BASE_URL}/{DEFAULT_API_VERSION}"
-
-
-@pytest.mark.asyncio
-async def test_custom_api_version():
-    """Test custom api version."""
-    async with PyLaunches(api_version="0.1.0") as client:
-        assert client._base_url == f"{BASE_URL}/0.1.0"
+        assert client._base_url == f"{BASE_URL}/{API_VERSION}"
 
 
 @pytest.mark.asyncio
 async def test_dev_url():
-    """Test custom api version."""
+    """Test dev URL."""
     async with PyLaunches(dev=True) as client:
-        assert client._base_url == f"{DEV_BASE_URL}/{DEFAULT_API_VERSION}"
+        assert client._base_url == f"{DEV_BASE_URL}/{API_VERSION}"


### PR DESCRIPTION
As noted in https://github.com/ludeeus/pylaunches/issues/59 the API has breaking changes even with minor version changes, which makes the ability to select version useless.